### PR TITLE
Fix twitter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Options:
   --url=VALUE, -u VALUE             # Site URL, default: "https://example.com"
   --title=VALUE, -t VALUE           # Site title, default: "Example"
   --description=VALUE, -d VALUE     # Site description, default: "Example site"
-  --twitter=VALUE, -t VALUE         # Twitter handle, default: ""
+  --twitter=VALUE, -x VALUE         # Twitter handle, default: ""
   --help, -h                        # Print this help
 ```
 

--- a/lib/staticky/cli/commands/generate.rb
+++ b/lib/staticky/cli/commands/generate.rb
@@ -25,7 +25,7 @@ module Staticky
         option :twitter,
                default: "",
                desc: "Twitter handle",
-               aliases: ["-t"]
+               aliases: ["-x"]
 
         def call(path:, **)
           path = Pathname.new(path).expand_path


### PR DESCRIPTION
There was a conflict between the abbreviations for the `--twitter` and `--title` command line options.  This proposes a fix for the conflict.